### PR TITLE
Fixes 64-bit header size issue

### DIFF
--- a/src/eris.c
+++ b/src/eris.c
@@ -2300,7 +2300,16 @@ u_header(Info *info) {
   if (strncmp(kHeader, header, HEADER_LENGTH)) {
     luaL_error(info->L, "invalid data");
   }
-  if (READ_VALUE(uint8_t) != sizeof(lua_Number)) {
+  uint8_t number_size = READ_VALUE(uint8_t);
+  if (number_size == 0) {
+    /* Old 64-bit versions of eris wrote '\0' and then three random bytes. */
+    /* We skip them here for backwards compatibility. */
+    char throw_away[3];
+    READ_RAW(throw_away, 3);
+
+    number_size = READ_VALUE(uint8_t);
+  }
+  if (number_size != sizeof(lua_Number)) {
     luaL_error(info->L, "incompatible floating point type");
   }
   /* In this case we really do want floating point equality. */


### PR DESCRIPTION
I received a warning when compiling Eris with Clang, which pointed me to this bug. the sizeof(kHeader) in the next line was actually producing the size of the `kHeader` _pointer_ (i.e. 4 bytes on a 32 bit system, 8 bytes on my 64-bit one), not the size of the "ERIS" string (which is actually 5 bytes in length). The result is that the header produced by my build of Eris was (hex) `45 52 49 53 00 63 6f 75` -- that is, the 4 bytes in "ERIS", the terminating null byte, and 3 garbage bytes. 

So, I've changed this global to be the four-byte-long header which I assume was the original intent. This doesn't change the behavior on 32-bit systems, but would introduce backward-incompatibility with old versions of Eris built on 64-bit systems, so I've also added detection of this and skipping of the extra header bytes. You could leave that second commit out if backwards compatibility is not an issue, and people will get an "incompatible floating point type" error instead.
