### PR TITLE
fix passing negative stack indices to eris C api functions

### DIFF
--- a/src/eris.c
+++ b/src/eris.c
@@ -2693,8 +2693,10 @@ eris_undump(lua_State *L, lua_Reader reader, void *ud) {            /* perms? */
 /** ======================================================================== */
 
 LUA_API void
-eris_persist(lua_State *L, int perms, int value) {                    /* ...? */
+eris_persist(lua_State *L, int per, int val) {                        /* ...? */
   eris_checkstack(L, 3);
+  int perms = lua_absindex(L, per);
+  int value = lua_absindex(L, val);
   lua_pushcfunction(L, l_persist);                           /* ... l_persist */
   lua_pushvalue(L, perms);                             /* ... l_persist perms */
   lua_pushvalue(L, value);                     /* ... l_persist perms rootobj */
@@ -2702,8 +2704,10 @@ eris_persist(lua_State *L, int perms, int value) {                    /* ...? */
 }
 
 LUA_API void
-eris_unpersist(lua_State *L, int perms, int value) {                   /* ... */
+eris_unpersist(lua_State *L, int per, int val) {                       /* ... */
   eris_checkstack(L, 3);
+  int perms = lua_absindex(L, per);
+  int value = lua_absindex(L, val);
   lua_pushcfunction(L, l_unpersist);                       /* ... l_unpersist */
   lua_pushvalue(L, perms);                           /* ... l_unpersist perms */
   lua_pushvalue(L, value);                       /* ... l_unpersist perms str */
@@ -2719,8 +2723,9 @@ eris_get_setting(lua_State *L, const char *name) {                     /* ... */
 }
 
 LUA_API void
-eris_set_setting(lua_State *L, const char *name, int value) {          /* ... */
+eris_set_setting(lua_State *L, const char *name, int val) {            /* ... */
   eris_checkstack(L, 3);
+  int value = lua_absindex(L, val);
   lua_pushcfunction(L, l_settings);                         /* ... l_settings */
   lua_pushstring(L, name);                             /* ... l_settings name */
   lua_pushvalue(L, value);                       /* ... l_settings name value */


### PR DESCRIPTION
I noticed a problem with the behavior of the eris C api function
"eris_set_setting" with regards to it handle negative stack
indices. Because the index is evaluated after the other C
arguments are pushed onto the stack, negative indices are off by
two and you get strange errors as a result.

This commit pushes the index argument (third) onto the stack first,
then the other two, then copies the index again, and removes the
original to remain stack neutral.

At first I thought that "eris_persist" and "eris_unpersist" must
have similar problems but now I think a similar change just isn't
appropriate -- I guess I just must remember not to use negative
indices with these functions?

It's somewhat annoying to me, I usually try to favor using
negative indices because you can't go wrong that way.

IMO a possible fix would be to change the signature of the
`eris_persist` and `eris_unpersist` C api functions so that
the `int value` argument is assumed to be at the top of the
stack. Then the persistence table can be given an arbitrary
index positive or negative I guess, since it could be pushed first,
and the second would be at -2 always? It seems more like the
other lua C api functions if it works that way. With the current
syntax I guess that the only way to support negative indices in
both places is if you do some case analysis based on the signs
of the arguments.

Thanks for making eris btw :)