### PR TITLE
WIP: Persist coroutines yielded from hook

### DIFF
--- a/persist_yielded_hook.lua
+++ b/persist_yielded_hook.lua
@@ -1,0 +1,24 @@
+local cr = coroutine.create(function()
+  for i = 1, 10 do
+    print('cr:', i)
+  end
+end)
+
+debug.sethook(cr, function() return true end, 'y', 20)
+
+print('A')
+coroutine.resume(cr)
+print('B')
+
+local t = eris.persist({[_ENV] = 1, [print] = 2}, cr)
+
+print('C')
+coroutine.resume(cr)
+print('D')
+
+cr = eris.unpersist({_ENV, print}, t)
+
+print('E')
+coroutine.resume(cr)
+print('F')
+

--- a/src/eris.c
+++ b/src/eris.c
@@ -185,7 +185,6 @@ extern void eris_permstrlib(lua_State *L, int forUnpersist);
 
 #define ERIS_ERR_CFUNC "attempt to persist a light C function (%p)"
 #define ERIS_ERR_COMPLEXITY "object too complex"
-#define ERIS_ERR_HOOK "cannot persist yielded hooks"
 #define ERIS_ERR_METATABLE "bad metatable, not nil or table"
 #define ERIS_ERR_NOFUNC "attempt to persist unknown function type"
 #define ERIS_ERR_READ "could not read data"
@@ -1746,12 +1745,18 @@ p_thread(Info *info) {                                          /* ... thread */
     }
 
     eris_assert(eris_isLua(ci) || (ci->callstatus & CIST_TAIL) == 0);
-    if (ci->callstatus & CIST_HOOKYIELD) {
-      eris_error(info, ERIS_ERR_HOOK);
-    }
 
     if (eris_isLua(ci)) {
-      const LClosure *lcl = eris_ci_func(ci);
+      StkId func = ci->func;
+      if (ci->callstatus & CIST_HOOKYIELD) {
+        /* Yielded from hook, mimic what resume does. */
+        ci->func = restorestack(thread, ci->extra);
+        /* Also, store ci->func for unpersisting,
+         * as ci->extra won't be restored yet. */
+        WRITE_VALUE(eris_savestackidx(thread, ci->func), size_t);
+      }
+      const LClosure *lcl = eris_ci_func(ci); /* Uses ci->func */
+      ci->func = func;
       WRITE_VALUE(eris_savestackidx(thread, ci->u.l.base), size_t);
       WRITE_VALUE(ci->u.l.savedpc - lcl->p->code, size_t);
     }
@@ -1916,7 +1921,13 @@ u_thread(Info *info) {                                                 /* ... */
     }
 
     if (eris_isLua(thread->ci)) {
-      LClosure *lcl = eris_ci_func(thread->ci);
+      StkId func = thread->ci->func;
+      if (thread->ci->callstatus & CIST_HOOKYIELD) {
+        /* See corresponding persist code */
+        thread->ci->func = eris_restorestackidx(thread, READ_VALUE(size_t));
+      }
+      LClosure *lcl = eris_ci_func(thread->ci); /* Uses ci->func */
+      thread->ci->func = func;
       thread->ci->u.l.base = eris_restorestackidx(thread, READ_VALUE(size_t));
       validate(thread->ci->u.l.base, thread->top);
       thread->ci->u.l.savedpc = lcl->p->code + READ_VALUE(size_t);

--- a/src/lua.h
+++ b/src/lua.h
@@ -371,6 +371,7 @@ LUA_API void      (lua_setallocf) (lua_State *L, lua_Alloc f, void *ud);
 #define LUA_MASKRET	(1 << LUA_HOOKRET)
 #define LUA_MASKLINE	(1 << LUA_HOOKLINE)
 #define LUA_MASKCOUNT	(1 << LUA_HOOKCOUNT)
+#define LUA_MASKYIELD	(1 << LUA_HOOKTAILCALL)
 
 typedef struct lua_Debug lua_Debug;  /* activation record */
 


### PR DESCRIPTION
Inspired by wanting preemptive multitasking in OpenComputers. See [my other repo](https://github.com/evg-zhabotinsky/yieldhook) for explanation of changes to `debug.sethook()` that let Lua hooks yield. After [posting to OC forum](https://oc.cil.li/index.php?/topic/1795-preemptive-multitasking-and-sysyield-timeouts/), it turned out that Eris cannot persist coroutines yielded from hooks (and even has a special error message for them), so here's my attempt to fix that.

The main problem seems to be that normal yields never happen from Lua code, there's no opcode for that. At the same time, hook yields look like such opcode was the last one, there's no enclosing C call. I assumed that this case should be treated the same way as a Lua stack frame, since it is one, but `thread->ci->func` no longer points to the closure and has to be `restorestack()`ed. I've additionally stored the value of restored `ci->func` for unpersisting, since `restorestack()` relies on `ci->extra`, which will only be unpersisted after the loop. ~This breaks serialization format compatibility, but is fine for testing, and a workaround can be implemented later.~ Actually, that only happens when persisting hook-yielded coroutines, so there's nothing to break.

This PR is a WIP, intended to be cleaned up and squashed when it's ready. The code currently seems to work, and I've added [a simple test](https://github.com/evg-zhabotinsky/eris/blob/persist-yielded-hook/persist_yielded_hook.lua) for it. However, I suspect more thorough testing is required, and I have no idea what kind of tests to make. I'm not very familiar with Lua and/or Eris internals. **Need help producing more tests!**

Currently known problems:
- [ ] The "native" `gmatch()` returns a closure that keeps its state in a userdata, and with yielding hooks it might have to be persisted. Maybe there are more similar cases.
- [ ] There definitely is some memory corruption going on. (Un)Persisting enough times leads to a state where some calls to `lua_pushvfstring(L, ".%s", "key")` reliably get "userdata" when pushing char* and fail, preventing any further persisting.
- [ ] Not sure if it's related to the corruption, but I'm periodically getting "attempt to persist userdata" messages. They never are as reliable as the above crashes.
- [ ] Neither of the 2 "userdata" problems reproduces without the full game, as of yet, so I cannot even use valgrind to look for them...